### PR TITLE
GUI의 아이템을 Rewards.yml 양식에 맞게 커스텀 가능하게끔 하기

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,13 +67,13 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.19.2-R0.1-SNAPSHOT</version>
+            <version>1.18.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>19.0.0</version>
+            <version>23.0.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/net/teamuni/dailyreward/ClickEvent.java
+++ b/src/main/java/net/teamuni/dailyreward/ClickEvent.java
@@ -9,7 +9,7 @@ import org.bukkit.inventory.Inventory;
 public class ClickEvent implements Listener {
     private final Inventory inventory;
     public ClickEvent(RewardManager rewardManager){
-        this.inventory = rewardManager.DailyRewardGui;
+        this.inventory = rewardManager.dailyRewardGui;
     }
 
 

--- a/src/main/java/net/teamuni/dailyreward/ClickEvent.java
+++ b/src/main/java/net/teamuni/dailyreward/ClickEvent.java
@@ -8,11 +8,13 @@ import org.bukkit.event.inventory.InventoryDragEvent;
 public class ClickEvent implements Listener {
     @EventHandler
     public void clickEvent(InventoryClickEvent e) {
+        if (!e.getInventory().equals(RewardManager.DailyRewardGui)) return;
         e.setCancelled(true);
-    }
 
+    }
     @EventHandler
-    public void clickEvent(InventoryDragEvent e) {
+    public void dragEvent(InventoryDragEvent e) {
+        if (!e.getInventory().equals(RewardManager.DailyRewardGui)) return;
         e.setCancelled(true);
     }
 }

--- a/src/main/java/net/teamuni/dailyreward/ClickEvent.java
+++ b/src/main/java/net/teamuni/dailyreward/ClickEvent.java
@@ -1,0 +1,13 @@
+package net.teamuni.dailyreward;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+
+public class ClickEvent implements Listener {
+    @EventHandler
+    public void clickEvent(InventoryClickEvent e){
+
+        e.setCancelled(true);
+    }
+}

--- a/src/main/java/net/teamuni/dailyreward/ClickEvent.java
+++ b/src/main/java/net/teamuni/dailyreward/ClickEvent.java
@@ -6,8 +6,7 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 
 public class ClickEvent implements Listener {
     @EventHandler
-    public void clickEvent(InventoryClickEvent e){
-
+    public void clickEvent(InventoryClickEvent e) {
         e.setCancelled(true);
     }
 }

--- a/src/main/java/net/teamuni/dailyreward/ClickEvent.java
+++ b/src/main/java/net/teamuni/dailyreward/ClickEvent.java
@@ -4,17 +4,23 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.inventory.Inventory;
 
 public class ClickEvent implements Listener {
+    private final Inventory inventory;
+    public ClickEvent(RewardManager rewardManager){
+        this.inventory = rewardManager.DailyRewardGui;
+    }
+
+
     @EventHandler
     public void clickEvent(InventoryClickEvent e) {
-        if (!e.getInventory().equals(RewardManager.DailyRewardGui)) return;
+        if(!e.getInventory().equals(inventory)) return;
         e.setCancelled(true);
-
     }
     @EventHandler
     public void dragEvent(InventoryDragEvent e) {
-        if (!e.getInventory().equals(RewardManager.DailyRewardGui)) return;
+        if(!e.getInventory().equals(inventory)) return;
         e.setCancelled(true);
     }
 }

--- a/src/main/java/net/teamuni/dailyreward/ClickEvent.java
+++ b/src/main/java/net/teamuni/dailyreward/ClickEvent.java
@@ -3,10 +3,16 @@ package net.teamuni.dailyreward;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
 
 public class ClickEvent implements Listener {
     @EventHandler
     public void clickEvent(InventoryClickEvent e) {
+        e.setCancelled(true);
+    }
+
+    @EventHandler
+    public void clickEvent(InventoryDragEvent e) {
         e.setCancelled(true);
     }
 }

--- a/src/main/java/net/teamuni/dailyreward/Dailyreward.java
+++ b/src/main/java/net/teamuni/dailyreward/Dailyreward.java
@@ -3,32 +3,44 @@ package net.teamuni.dailyreward;
 import org.bukkit.*;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 
-public final class Dailyreward extends JavaPlugin implements Listener {
+import java.util.*;
 
+public final class Dailyreward extends JavaPlugin implements Listener {
+    private final Map<Integer, ItemStack> dailyItem = new HashMap<>();
+    private final Set<ItemMeta> dailyItemMetaSet = new HashSet<>();
 
     @Override
     public void onEnable() {
+        getServer().getPluginManager().registerEvents(new ClickEvent(), this);
+        RewardManager.createRewardsYml();
     }
 
     @Override
     public void onDisable() {
         // Plugin shutdown logic
     }
+
     @Override
     public boolean onCommand(@NotNull CommandSender sender, Command cmd, @NotNull String label, String[] args) {
         Player player = (Player) sender;
         if (cmd.getName().equals("출석체크") && player.hasPermission("dailyreward.opengui")) {
+            dailyItem.putAll(RewardManager.getRewards("Rewards"));
+            for (ItemStack itemStack : dailyItem.values()) {
+                this.dailyItemMetaSet.add(itemStack.getItemMeta());
+            }
             Inventory DailyRewardGui = Bukkit.createInventory(player, 54, ChatColor.GREEN + "출석체크 GUI");
-            ItemStack day1 = new ItemStack(Material.CHEST_MINECART);
-            ItemStack[] DailyRewardItems = {day1};
-            DailyRewardGui.setContents(DailyRewardItems);
+            for (Map.Entry<Integer, ItemStack> dailyitems : dailyItem.entrySet()){
+                DailyRewardGui.setItem(dailyitems.getKey(), dailyitems.getValue());
+            }
             player.openInventory(DailyRewardGui);
         }
         return true;

--- a/src/main/java/net/teamuni/dailyreward/Dailyreward.java
+++ b/src/main/java/net/teamuni/dailyreward/Dailyreward.java
@@ -29,7 +29,7 @@ public final class Dailyreward extends JavaPlugin implements Listener {
     public boolean onCommand(@NotNull CommandSender sender, Command cmd, @NotNull String label, String[] args) {
         Player player = (Player) sender;
         if (cmd.getName().equals("출석체크") && player.hasPermission("dailyreward.opengui")) {
-            player.openInventory(rewardManager.DailyRewardGui);
+            player.openInventory(rewardManager.dailyRewardGui);
         }
         if (cmd.getName().equals("dailyreward") && player.hasPermission("dailyreward.reload")) {
             if (args.length > 0) {

--- a/src/main/java/net/teamuni/dailyreward/Dailyreward.java
+++ b/src/main/java/net/teamuni/dailyreward/Dailyreward.java
@@ -1,47 +1,34 @@
 package net.teamuni.dailyreward;
 
-import org.bukkit.*;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
-import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
-
 public final class Dailyreward extends JavaPlugin implements Listener {
-    private final Map<Integer, ItemStack> dailyItem = new HashMap<>();
-    private final Set<ItemMeta> dailyItemMetaSet = new HashSet<>();
 
     @Override
     public void onEnable() {
         getServer().getPluginManager().registerEvents(new ClickEvent(), this);
-        RewardManager.createRewardsYml();
+        RewardManager rm = new RewardManager();
+        rm.createRewardsYml();
+        rm.setGui();
     }
 
     @Override
     public void onDisable() {
-        // Plugin shutdown logic
+        RewardManager rm = new RewardManager();
+        rm.save();
     }
+
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, Command cmd, @NotNull String label, String[] args) {
         Player player = (Player) sender;
         if (cmd.getName().equals("출석체크") && player.hasPermission("dailyreward.opengui")) {
-            dailyItem.putAll(RewardManager.getRewards("Rewards"));
-            for (ItemStack itemStack : dailyItem.values()) {
-                this.dailyItemMetaSet.add(itemStack.getItemMeta());
-            }
-            Inventory DailyRewardGui = Bukkit.createInventory(player, 54, ChatColor.GREEN + "출석체크 GUI");
-            for (Map.Entry<Integer, ItemStack> dailyitems : dailyItem.entrySet()){
-                DailyRewardGui.setItem(dailyitems.getKey(), dailyitems.getValue());
-            }
-            player.openInventory(DailyRewardGui);
+            player.openInventory(RewardManager.DailyRewardGui);
         }
         return true;
     }

--- a/src/main/java/net/teamuni/dailyreward/Dailyreward.java
+++ b/src/main/java/net/teamuni/dailyreward/Dailyreward.java
@@ -20,6 +20,7 @@ public final class Dailyreward extends JavaPlugin implements Listener {
     @Override
     public void onDisable() {
         RewardManager rm = new RewardManager();
+        rm.reload();
         rm.save();
     }
 

--- a/src/main/java/net/teamuni/dailyreward/Dailyreward.java
+++ b/src/main/java/net/teamuni/dailyreward/Dailyreward.java
@@ -35,7 +35,6 @@ public final class Dailyreward extends JavaPlugin implements Listener {
             if (args.length > 0) {
                 if (args[0].equals("reload")) {
                     rm.reload();
-                    rm.save();
                     rm.setGui();
                     player.sendMessage(ChatColor.YELLOW + "[알림]" + ChatColor.WHITE + " DailyReward 플러그인이 리로드되었습니다.");
                     return true;

--- a/src/main/java/net/teamuni/dailyreward/Dailyreward.java
+++ b/src/main/java/net/teamuni/dailyreward/Dailyreward.java
@@ -9,14 +9,15 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 
 public final class Dailyreward extends JavaPlugin implements Listener {
+    private RewardManager rewardManager;
 
 
     @Override
     public void onEnable() {
-        getServer().getPluginManager().registerEvents(new ClickEvent(), this);
-        RewardManager rm = new RewardManager();
-        rm.createRewardsYml();
-        rm.setGui();
+        this.rewardManager = new RewardManager();
+        getServer().getPluginManager().registerEvents(new ClickEvent(rewardManager), this);
+        rewardManager.createRewardsYml();
+        rewardManager.setGui();
     }
 
     @Override
@@ -26,16 +27,15 @@ public final class Dailyreward extends JavaPlugin implements Listener {
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, Command cmd, @NotNull String label, String[] args) {
-        RewardManager rm = new RewardManager();
         Player player = (Player) sender;
         if (cmd.getName().equals("출석체크") && player.hasPermission("dailyreward.opengui")) {
-            player.openInventory(rm.DailyRewardGui);
+            player.openInventory(rewardManager.DailyRewardGui);
         }
         if (cmd.getName().equals("dailyreward") && player.hasPermission("dailyreward.reload")) {
             if (args.length > 0) {
                 if (args[0].equals("reload")) {
-                    rm.reload();
-                    rm.setGui();
+                    rewardManager.reload();
+                    rewardManager.setGui();
                     player.sendMessage(ChatColor.YELLOW + "[알림]" + ChatColor.WHITE + " DailyReward 플러그인이 리로드되었습니다.");
                     return true;
                 }

--- a/src/main/java/net/teamuni/dailyreward/Dailyreward.java
+++ b/src/main/java/net/teamuni/dailyreward/Dailyreward.java
@@ -1,5 +1,6 @@
 package net.teamuni.dailyreward;
 
+import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -8,6 +9,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 
 public final class Dailyreward extends JavaPlugin implements Listener {
+
 
     @Override
     public void onEnable() {
@@ -19,17 +21,29 @@ public final class Dailyreward extends JavaPlugin implements Listener {
 
     @Override
     public void onDisable() {
-        RewardManager rm = new RewardManager();
-        rm.reload();
-        rm.save();
     }
 
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, Command cmd, @NotNull String label, String[] args) {
+        RewardManager rm = new RewardManager();
         Player player = (Player) sender;
         if (cmd.getName().equals("출석체크") && player.hasPermission("dailyreward.opengui")) {
-            player.openInventory(RewardManager.DailyRewardGui);
+            player.openInventory(rm.DailyRewardGui);
+        }
+        if (cmd.getName().equals("dailyreward") && player.hasPermission("dailyreward.reload")) {
+            if (args.length > 0) {
+                if (args[0].equals("reload")) {
+                    rm.reload();
+                    rm.save();
+                    rm.setGui();
+                    player.sendMessage(ChatColor.YELLOW + "[알림]" + ChatColor.WHITE + " DailyReward 플러그인이 리로드되었습니다.");
+                    return true;
+                }
+            } else {
+                player.sendMessage(ChatColor.YELLOW + "[알림]" + ChatColor.WHITE + " 알 수 없는 명령어 입니다.");
+                return true;
+            }
         }
         return true;
     }

--- a/src/main/java/net/teamuni/dailyreward/RewardManager.java
+++ b/src/main/java/net/teamuni/dailyreward/RewardManager.java
@@ -3,6 +3,7 @@ package net.teamuni.dailyreward;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.event.Listener;
@@ -22,7 +23,7 @@ public class RewardManager implements Listener {
     private final Set<ItemMeta> dailyItemMetaSet = new HashSet<>();
     private File file = null;
     private FileConfiguration rewardsFile = null;
-    public final Inventory DailyRewardGui = Bukkit.createInventory(null, 54, ChatColor.GREEN + "출석체크 GUI");
+    public final Inventory dailyRewardGui = Bukkit.createInventory(null, 54, ChatColor.GREEN + "출석체크 GUI");
 
     public void createRewardsYml() {
         this.file = new File(main.getDataFolder(), "rewards.yml");
@@ -32,14 +33,11 @@ public class RewardManager implements Listener {
         }
         this.rewardsFile = YamlConfiguration.loadConfiguration(file);
     }
-    public FileConfiguration getConfig() {
-        return this.rewardsFile;
-    }
 
     public void reload() {
         this.rewardsFile = YamlConfiguration.loadConfiguration(file);
     }
-    
+
     /*
     public void save() {
         try{
@@ -53,30 +51,35 @@ public class RewardManager implements Listener {
     @NotNull
     public Map<Integer, ItemStack> getRewards(String path){
         Map<Integer, ItemStack> rewards = new HashMap<>();
-        Set<String> rewardsKeys = getConfig().getConfigurationSection(path).getKeys(false);
+        ConfigurationSection section = this.rewardsFile.getConfigurationSection(path);
+        Set<String> rewardsKeys = section.getKeys(false);
         if (rewardsKeys.isEmpty()) {
-            throw new IllegalArgumentException("rewards.yml 에서 문제가 발생했습니다.");
+            throw new IllegalArgumentException("rewards.yml 파일의 내용이 비어있습니다. rewards.yml파일을 확인해주세요.");
         }
         for (String key : rewardsKeys) {
-            int slot = getConfig().getInt(path + "." + key + ".slot");
+            int slot = section.getInt(key + ".slot");
             try {
-                ItemStack rewardsItem = new ItemStack(Material.valueOf(getConfig().getString(path + "." + key +".item_type")));
+                ItemStack rewardsItem = new ItemStack(Material.valueOf(section.getString(key + ".item_type")));
                 ItemMeta meta = rewardsItem.getItemMeta();
-                String rewardsName = getConfig().getString(path + "." + key + ".name");
+                String rewardsName = section.getString(key + ".name");
                 List<String> rewardLoreList = new ArrayList<>();
                 List<String> commandList = new ArrayList<>();
-                for (String lores : getConfig().getStringList(path + "." + key + ".lore")){
+                for (String lores : section.getStringList(key + ".lore")){
                     rewardLoreList.add(ChatColor.translateAlternateColorCodes('&', lores));
                 }
-                for (String commands : getConfig().getStringList(path + "." + key + ".commands")){
+                for (String commands : section.getStringList(key + ".commands")){
                     commandList.add(commands);
                 }
-                meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', rewardsName));
+                if (rewardsName != null) {
+                    meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', rewardsName));
+                } else {
+                    Bukkit.getLogger().info("rewards.yml 파일중 보상의 이름이 없습니다. rewards.yml을 확인해주세요.");
+                }
                 meta.setLore(rewardLoreList);
                 meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
                 rewardsItem.setItemMeta(meta);
                 rewards.put(slot, rewardsItem);
-            } catch (NullPointerException | IllegalArgumentException e) {
+            } catch (IllegalArgumentException e) {
                 e.printStackTrace();
             }
         }
@@ -89,7 +92,7 @@ public class RewardManager implements Listener {
             this.dailyItemMetaSet.add(itemStack.getItemMeta());
         }
         for (Map.Entry<Integer, ItemStack> dailyitems : this.dailyItem.entrySet()){
-            this.DailyRewardGui.setItem(dailyitems.getKey(), dailyitems.getValue());
+            this.dailyRewardGui.setItem(dailyitems.getKey(), dailyitems.getValue());
         }
     }
 }

--- a/src/main/java/net/teamuni/dailyreward/RewardManager.java
+++ b/src/main/java/net/teamuni/dailyreward/RewardManager.java
@@ -1,9 +1,15 @@
 package net.teamuni.dailyreward;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -13,12 +19,16 @@ import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
-public class RewardManager {
+public class RewardManager implements Listener {
     private static final Dailyreward main = Dailyreward.getPlugin(Dailyreward.class);
+    private static final Map<Integer, ItemStack> dailyItem = new HashMap<>();
+    private static final Set<ItemMeta> dailyItemMetaSet = new HashSet<>();
     private static File file;
     private static FileConfiguration rewardsFile;
 
-    public static void createRewardsYml() {
+    public static final Inventory DailyRewardGui = Bukkit.createInventory(null, 54, ChatColor.GREEN + "출석체크 GUI");
+
+    public void createRewardsYml() {
         file = new File(main.getDataFolder(), "rewards.yml");
 
         if (!file.exists()) {
@@ -31,19 +41,19 @@ public class RewardManager {
     }
 
 
-    public static void save() {
+    public void save() {
         try {
             rewardsFile.save(file);
         } catch (IOException e) {
             e.printStackTrace();
         }
     }
-    public static void reload() {
+    public void reload() {
         rewardsFile = YamlConfiguration.loadConfiguration(file);
     }
 
     @NotNull
-    public static Map<Integer, ItemStack> getRewards(String path){
+    public Map<Integer, ItemStack> getRewards(String path){
         Map<Integer, ItemStack> rewards = new HashMap<>();
         Set<String> rewardsKeys = getConfig().getConfigurationSection(path).getKeys(false);
         if (rewardsKeys.isEmpty()) {
@@ -69,5 +79,15 @@ public class RewardManager {
             }
         }
         return rewards;
+    }
+
+    public void setGui(){
+        dailyItem.putAll(getRewards("Rewards"));
+        for (ItemStack itemStack : dailyItem.values()) {
+            dailyItemMetaSet.add(itemStack.getItemMeta());
+        }
+        for (Map.Entry<Integer, ItemStack> dailyitems : dailyItem.entrySet()){
+            DailyRewardGui.setItem(dailyitems.getKey(), dailyitems.getValue());
+        }
     }
 }

--- a/src/main/java/net/teamuni/dailyreward/RewardManager.java
+++ b/src/main/java/net/teamuni/dailyreward/RewardManager.java
@@ -20,34 +20,35 @@ public class RewardManager implements Listener {
     private final Dailyreward main = Dailyreward.getPlugin(Dailyreward.class);
     private final Map<Integer, ItemStack> dailyItem = new HashMap<>();
     private final Set<ItemMeta> dailyItemMetaSet = new HashSet<>();
-    private File file;
-    private FileConfiguration rewardsFile;
-
-    public static final Inventory DailyRewardGui = Bukkit.createInventory(null, 54, ChatColor.GREEN + "출석체크 GUI");
+    private File file = null;
+    private FileConfiguration rewardsFile = null;
+    public final Inventory DailyRewardGui = Bukkit.createInventory(null, 54, ChatColor.GREEN + "출석체크 GUI");
 
     public void createRewardsYml() {
-        file = new File(main.getDataFolder(), "rewards.yml");
+        this.file = new File(main.getDataFolder(), "rewards.yml");
 
         if (!file.exists()) {
             main.saveResource("rewards.yml", false);
         }
-        rewardsFile = YamlConfiguration.loadConfiguration(file);
+        this.rewardsFile = YamlConfiguration.loadConfiguration(file);
     }
     public FileConfiguration getConfig() {
-        return rewardsFile;
+        return this.rewardsFile;
     }
 
-
+    public void reload() {
+        this.rewardsFile = YamlConfiguration.loadConfiguration(file);
+    }
+    
+    /*
     public void save() {
-        try {
-            rewardsFile.save(file);
-        } catch (IOException e) {
+        try{
+            this.rewardsFile.save(file);
+        } catch (IOException e){
             e.printStackTrace();
         }
     }
-    public void reload() {
-        rewardsFile = YamlConfiguration.loadConfiguration(file);
-    }
+     */
 
     @NotNull
     public Map<Integer, ItemStack> getRewards(String path){
@@ -63,8 +64,12 @@ public class RewardManager implements Listener {
                 ItemMeta meta = rewardsItem.getItemMeta();
                 String rewardsName = getConfig().getString(path + "." + key + ".name");
                 List<String> rewardLoreList = new ArrayList<>();
+                List<String> commandList = new ArrayList<>();
                 for (String lores : getConfig().getStringList(path + "." + key + ".lore")){
                     rewardLoreList.add(ChatColor.translateAlternateColorCodes('&', lores));
+                }
+                for (String commands : getConfig().getStringList(path + "." + key + ".commands")){
+                    commandList.add(commands);
                 }
                 meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', rewardsName));
                 meta.setLore(rewardLoreList);
@@ -79,12 +84,12 @@ public class RewardManager implements Listener {
     }
 
     public void setGui(){
-        dailyItem.putAll(getRewards("Rewards"));
-        for (ItemStack itemStack : dailyItem.values()) {
-            dailyItemMetaSet.add(itemStack.getItemMeta());
+        this.dailyItem.putAll(getRewards("Rewards"));
+        for (ItemStack itemStack : this.dailyItem.values()) {
+            this.dailyItemMetaSet.add(itemStack.getItemMeta());
         }
-        for (Map.Entry<Integer, ItemStack> dailyitems : dailyItem.entrySet()){
-            DailyRewardGui.setItem(dailyitems.getKey(), dailyitems.getValue());
+        for (Map.Entry<Integer, ItemStack> dailyitems : this.dailyItem.entrySet()){
+            this.DailyRewardGui.setItem(dailyitems.getKey(), dailyitems.getValue());
         }
     }
 }

--- a/src/main/java/net/teamuni/dailyreward/RewardManager.java
+++ b/src/main/java/net/teamuni/dailyreward/RewardManager.java
@@ -5,10 +5,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
@@ -20,8 +17,8 @@ import java.io.IOException;
 import java.util.*;
 
 public class RewardManager implements Listener {
-    private static final Dailyreward main = Dailyreward.getPlugin(Dailyreward.class);
-    private static final Map<Integer, ItemStack> dailyItem = new HashMap<>();
+    private final Dailyreward main = Dailyreward.getPlugin(Dailyreward.class);
+    private final Map<Integer, ItemStack> dailyItem = new HashMap<>();
     private static final Set<ItemMeta> dailyItemMetaSet = new HashSet<>();
     private static File file;
     private static FileConfiguration rewardsFile;

--- a/src/main/java/net/teamuni/dailyreward/RewardManager.java
+++ b/src/main/java/net/teamuni/dailyreward/RewardManager.java
@@ -19,9 +19,9 @@ import java.util.*;
 public class RewardManager implements Listener {
     private final Dailyreward main = Dailyreward.getPlugin(Dailyreward.class);
     private final Map<Integer, ItemStack> dailyItem = new HashMap<>();
-    private static final Set<ItemMeta> dailyItemMetaSet = new HashSet<>();
-    private static File file;
-    private static FileConfiguration rewardsFile;
+    private final Set<ItemMeta> dailyItemMetaSet = new HashSet<>();
+    private File file;
+    private FileConfiguration rewardsFile;
 
     public static final Inventory DailyRewardGui = Bukkit.createInventory(null, 54, ChatColor.GREEN + "출석체크 GUI");
 
@@ -33,7 +33,7 @@ public class RewardManager implements Listener {
         }
         rewardsFile = YamlConfiguration.loadConfiguration(file);
     }
-    public static FileConfiguration getConfig() {
+    public FileConfiguration getConfig() {
         return rewardsFile;
     }
 

--- a/src/main/java/net/teamuni/dailyreward/RewardManager.java
+++ b/src/main/java/net/teamuni/dailyreward/RewardManager.java
@@ -57,17 +57,18 @@ public class RewardManager implements Listener {
             throw new IllegalArgumentException("rewards.yml 파일의 내용이 비어있습니다. rewards.yml파일을 확인해주세요.");
         }
         for (String key : rewardsKeys) {
+            ConfigurationSection sectionSecond = section.getConfigurationSection(key);
             int slot = section.getInt(key + ".slot");
             try {
-                ItemStack rewardsItem = new ItemStack(Material.valueOf(section.getString(key + ".item_type")));
+                ItemStack rewardsItem = new ItemStack(Material.valueOf(sectionSecond.getString("item_type")));
                 ItemMeta meta = rewardsItem.getItemMeta();
-                String rewardsName = section.getString(key + ".name");
+                String rewardsName = sectionSecond.getString("name");
                 List<String> rewardLoreList = new ArrayList<>();
                 List<String> commandList = new ArrayList<>();
-                for (String lores : section.getStringList(key + ".lore")){
+                for (String lores : sectionSecond.getStringList("lore")){
                     rewardLoreList.add(ChatColor.translateAlternateColorCodes('&', lores));
                 }
-                for (String commands : section.getStringList(key + ".commands")){
+                for (String commands : sectionSecond.getStringList("commands")){
                     commandList.add(commands);
                 }
                 if (rewardsName != null) {

--- a/src/main/java/net/teamuni/dailyreward/RewardManager.java
+++ b/src/main/java/net/teamuni/dailyreward/RewardManager.java
@@ -4,6 +4,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
@@ -60,6 +61,7 @@ public class RewardManager {
                 }
                 meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', rewardsName));
                 meta.setLore(rewardLoreList);
+                meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
                 rewardsItem.setItemMeta(meta);
                 rewards.put(slot, rewardsItem);
             } catch (NullPointerException | IllegalArgumentException e) {

--- a/src/main/java/net/teamuni/dailyreward/RewardManager.java
+++ b/src/main/java/net/teamuni/dailyreward/RewardManager.java
@@ -21,11 +21,11 @@ public class RewardManager {
         file = new File(main.getDataFolder(), "rewards.yml");
 
         if (!file.exists()) {
-            main.saveResource("messages.yml", false);
+            main.saveResource("rewards.yml", false);
         }
         rewardsFile = YamlConfiguration.loadConfiguration(file);
     }
-    public FileConfiguration getConfig() {
+    public static FileConfiguration getConfig() {
         return rewardsFile;
     }
 
@@ -42,25 +42,21 @@ public class RewardManager {
     }
 
     @NotNull
-    public Map<Integer, ItemStack> getRewards(String path){
+    public static Map<Integer, ItemStack> getRewards(String path){
         Map<Integer, ItemStack> rewards = new HashMap<>();
-        Set<String> rewardsKeys = this.getConfig().getConfigurationSection(path).getKeys(false);
+        Set<String> rewardsKeys = getConfig().getConfigurationSection(path).getKeys(false);
         if (rewardsKeys.isEmpty()) {
             throw new IllegalArgumentException("rewards.yml 에서 문제가 발생했습니다.");
         }
         for (String key : rewardsKeys) {
-            int slot = this.getConfig().getInt(path + "." + key + ".slot");
+            int slot = getConfig().getInt(path + "." + key + ".slot");
             try {
-                ItemStack rewardsItem = new ItemStack(Material.valueOf(this.getConfig().getString(path + "." + key +".item_type")));
+                ItemStack rewardsItem = new ItemStack(Material.valueOf(getConfig().getString(path + "." + key +".item_type")));
                 ItemMeta meta = rewardsItem.getItemMeta();
-                String rewardsName = this.getConfig().getString(path + "." + key + ".name");
+                String rewardsName = getConfig().getString(path + "." + key + ".name");
                 List<String> rewardLoreList = new ArrayList<>();
-                for (String lores : this.getConfig().getStringList(path + "." + key + ".lore")){
+                for (String lores : getConfig().getStringList(path + "." + key + ".lore")){
                     rewardLoreList.add(ChatColor.translateAlternateColorCodes('&', lores));
-                }
-                List<String> rewardCommandList = new ArrayList<>();
-                for (String rewardscommands : this.getConfig().getStringList(path + "." + key + ".commands")){
-                    rewardCommandList.add(rewardscommands);
                 }
                 meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', rewardsName));
                 meta.setLore(rewardLoreList);

--- a/src/main/java/net/teamuni/dailyreward/RewardManager.java
+++ b/src/main/java/net/teamuni/dailyreward/RewardManager.java
@@ -1,0 +1,75 @@
+package net.teamuni.dailyreward;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+public class RewardManager {
+    private static final Dailyreward main = Dailyreward.getPlugin(Dailyreward.class);
+    private static File file;
+    private static FileConfiguration rewardsFile;
+
+    public static void createRewardsYml() {
+        file = new File(main.getDataFolder(), "rewards.yml");
+
+        if (!file.exists()) {
+            main.saveResource("messages.yml", false);
+        }
+        rewardsFile = YamlConfiguration.loadConfiguration(file);
+    }
+    public FileConfiguration getConfig() {
+        return rewardsFile;
+    }
+
+
+    public static void save() {
+        try {
+            rewardsFile.save(file);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+    public static void reload() {
+        rewardsFile = YamlConfiguration.loadConfiguration(file);
+    }
+
+    @NotNull
+    public Map<Integer, ItemStack> getRewards(String path){
+        Map<Integer, ItemStack> rewards = new HashMap<>();
+        Set<String> rewardsKeys = this.getConfig().getConfigurationSection(path).getKeys(false);
+        if (rewardsKeys.isEmpty()) {
+            throw new IllegalArgumentException("rewards.yml 에서 문제가 발생했습니다.");
+        }
+        for (String key : rewardsKeys) {
+            int slot = this.getConfig().getInt(path + "." + key + ".slot");
+            try {
+                ItemStack rewardsItem = new ItemStack(Material.valueOf(this.getConfig().getString(path + "." + key +".item_type")));
+                ItemMeta meta = rewardsItem.getItemMeta();
+                String rewardsName = this.getConfig().getString(path + "." + key + ".name");
+                List<String> rewardLoreList = new ArrayList<>();
+                for (String lores : this.getConfig().getStringList(path + "." + key + ".lore")){
+                    rewardLoreList.add(ChatColor.translateAlternateColorCodes('&', lores));
+                }
+                List<String> rewardCommandList = new ArrayList<>();
+                for (String rewardscommands : this.getConfig().getStringList(path + "." + key + ".commands")){
+                    rewardCommandList.add(rewardscommands);
+                }
+                meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', rewardsName));
+                meta.setLore(rewardLoreList);
+                rewardsItem.setItemMeta(meta);
+                rewards.put(slot, rewardsItem);
+            } catch (NullPointerException | IllegalArgumentException e) {
+                e.printStackTrace();
+            }
+        }
+        return rewards;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,6 +5,8 @@ api-version: 1.18
 commands:
   출석체크:
     permission: dailyreward.opengui
+  dailyreward:
+    permission: dailyreward.reload
 permissions:
   dailyreward.opengui:
     default: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,4 +4,10 @@ main: net.teamuni.dailyreward.Dailyreward
 api-version: 1.18
 commands:
   출석체크:
+    permission: dailyreward.opengui
+permissions:
+  dailyreward.opengui:
+    default: true
+  dailyreward.reload:
+    default: op
 

--- a/src/main/resources/rewards.yml
+++ b/src/main/resources/rewards.yml
@@ -1,7 +1,8 @@
 Rewards:
   day1:
     slot: 0
-    name: "&a1일차"
+    name: "&a1일차 보상"
+    item_type: "EMERALD"
     lore:
       - ""
     commands:

--- a/src/main/resources/rewards.yml
+++ b/src/main/resources/rewards.yml
@@ -1,0 +1,8 @@
+Rewards:
+  day1:
+    slot: 0
+    name: "&a1일차"
+    lore:
+      - ""
+    commands:
+      - ""


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/71818357/192517701-567dd56e-62c5-4e0d-a8f6-155f127a2b60.png)
기본 Rewards.yml 의 파일.

![image](https://user-images.githubusercontent.com/71818357/192517802-db0f555f-65cb-4583-ba1c-502ca6ec6bb3.png)
적용 되는 출석체크의 GUI

![image](https://user-images.githubusercontent.com/71818357/192518391-e9a306dd-6b7b-4472-a134-e56ba58e1074.png)
커스텀을 한 Rewards.yml의 파일

![image](https://user-images.githubusercontent.com/71818357/192518445-e8e58c3b-2608-4d44-a068-e89dfb47405f.png)
커스텀이 적용되는 출석체크의 GUI

![image](https://user-images.githubusercontent.com/71818357/192518512-381ffd16-1287-44dd-884b-1e5e732d78f9.png)

![image](https://user-images.githubusercontent.com/71818357/192518535-7de7c702-0541-4cd7-abab-f524db766ac9.png)
그리고 커스텀이 된 아이템의 모습

