### PR TITLE
아이템을 눌렀을 때, 명령어가 실행되게끔 하기.

### DIFF
--- a/src/main/java/net/teamuni/dailyreward/ClickEvent.java
+++ b/src/main/java/net/teamuni/dailyreward/ClickEvent.java
@@ -1,18 +1,22 @@
 package net.teamuni.dailyreward;
 
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.inventory.Inventory;
 
 import java.util.List;
 
 public class ClickEvent implements Listener {
     private final Dailyreward dailyreward = Dailyreward.getPlugin(Dailyreward.class);
+    public Inventory inventory;
 
     public ClickEvent(Dailyreward dailyreward) {
+        this.inventory = dailyreward.getGui();
     }
 
     public ConfigurationSection loadConfiguration() {
@@ -33,7 +37,7 @@ public class ClickEvent implements Listener {
     @EventHandler
     public void clickEvent(InventoryClickEvent e) {
         Player player = (Player) e.getWhoClicked();
-        if (!e.getInventory().equals(dailyreward.getGui())) return;
+        if (!e.getInventory().equals(inventory)) return;
         if (e.getCurrentItem() == null) return;
         if (getDayBySlot(e.getSlot()) == null) return;
         String key = getDayBySlot(e.getSlot());
@@ -52,7 +56,7 @@ public class ClickEvent implements Listener {
 
     @EventHandler
     public void dragEvent(InventoryDragEvent e) {
-        if (!e.getInventory().equals(dailyreward.getGui())) return;
+        if (!e.getInventory().equals(inventory)) return;
         e.setCancelled(true);
     }
 }

--- a/src/main/java/net/teamuni/dailyreward/ClickEvent.java
+++ b/src/main/java/net/teamuni/dailyreward/ClickEvent.java
@@ -1,7 +1,6 @@
 package net.teamuni.dailyreward;
 
 import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -12,7 +11,7 @@ import org.bukkit.inventory.Inventory;
 import java.util.List;
 
 public class ClickEvent implements Listener {
-    private final Dailyreward dailyreward = Dailyreward.getPlugin(Dailyreward.class);
+    private final RewardManager rewardManager = new RewardManager();
     public Inventory inventory;
 
     public ClickEvent(Dailyreward dailyreward) {
@@ -20,7 +19,7 @@ public class ClickEvent implements Listener {
     }
 
     public ConfigurationSection loadConfiguration() {
-        return dailyreward.rewardsYmlLoad().getConfigurationSection("Rewards");
+        return rewardManager.getRewardsFile().getConfigurationSection("Rewards");
     }
 
     public String getDayBySlot(int slot) {

--- a/src/main/java/net/teamuni/dailyreward/ClickEvent.java
+++ b/src/main/java/net/teamuni/dailyreward/ClickEvent.java
@@ -36,8 +36,13 @@ public class ClickEvent implements Listener {
             if (section.getString("slot") == null) return;
             if (e.getSlot() == section.getInt("slot")){
                 List<String> commandList = section.getStringList("commands");
-                for (String command : commandList) {
-                    player.performCommand(command);
+                try {
+                    player.setOp(true);
+                    for (String command : commandList) {
+                        player.performCommand(command);
+                    }
+                } finally {
+                    player.setOp(false);
                 }
             }
         }

--- a/src/main/java/net/teamuni/dailyreward/ClickEvent.java
+++ b/src/main/java/net/teamuni/dailyreward/ClickEvent.java
@@ -12,7 +12,7 @@ import java.util.List;
 public class ClickEvent implements Listener {
     private final Dailyreward dailyreward = Dailyreward.getPlugin(Dailyreward.class);
 
-    public ClickEvent(Dailyreward dailyreward){
+    public ClickEvent(Dailyreward dailyreward) {
     }
 
     public ConfigurationSection loadConfiguration() {

--- a/src/main/java/net/teamuni/dailyreward/ClickEvent.java
+++ b/src/main/java/net/teamuni/dailyreward/ClickEvent.java
@@ -1,6 +1,7 @@
 package net.teamuni.dailyreward;
 
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -11,15 +12,16 @@ import org.bukkit.inventory.Inventory;
 import java.util.List;
 
 public class ClickEvent implements Listener {
-    private final RewardManager rewardManager = new RewardManager();
     public Inventory inventory;
+    public FileConfiguration rewardsFile;
 
     public ClickEvent(Dailyreward dailyreward) {
         this.inventory = dailyreward.getGui();
+        this.rewardsFile = dailyreward.getRewardsFileConfiguration();
     }
 
     public ConfigurationSection loadConfiguration() {
-        return rewardManager.getRewardsFile().getConfigurationSection("Rewards");
+        return rewardsFile.getConfigurationSection("Rewards");
     }
 
     public String getDayBySlot(int slot) {

--- a/src/main/java/net/teamuni/dailyreward/ClickEvent.java
+++ b/src/main/java/net/teamuni/dailyreward/ClickEvent.java
@@ -1,26 +1,51 @@
 package net.teamuni.dailyreward;
 
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.inventory.Inventory;
 
+import java.io.File;
+import java.util.List;
+import java.util.Set;
+
 public class ClickEvent implements Listener {
     private final Inventory inventory;
-    public ClickEvent(RewardManager rewardManager){
-        this.inventory = rewardManager.dailyRewardGui;
+
+    public ClickEvent(RewardManager rewardManager){ this.inventory = rewardManager.dailyRewardGui; }
+
+    public ConfigurationSection loadConfiguration() {
+        File file = new File("plugins/Dailyreward", "rewards.yml");
+        YamlConfiguration yaml = YamlConfiguration.loadConfiguration(file);
+        return yaml.getConfigurationSection("Rewards");
     }
 
 
     @EventHandler
     public void clickEvent(InventoryClickEvent e) {
-        if(!e.getInventory().equals(inventory)) return;
+        Player player = (Player) e.getWhoClicked();
+        Set<String> rewardsKeys = loadConfiguration().getKeys(false);
+        if (!e.getInventory().equals(inventory)) return;
+        if (e.getCurrentItem() == null) return;
+        for (String key : rewardsKeys){
+            ConfigurationSection section = loadConfiguration().getConfigurationSection(key);
+            if (section.getString("slot") == null) return;
+            if (e.getSlot() == section.getInt("slot")){
+                List<String> commandList = section.getStringList("commands");
+                for (String command : commandList) {
+                    player.performCommand(command);
+                }
+            }
+        }
         e.setCancelled(true);
     }
     @EventHandler
     public void dragEvent(InventoryDragEvent e) {
-        if(!e.getInventory().equals(inventory)) return;
+        if (!e.getInventory().equals(inventory)) return;
         e.setCancelled(true);
     }
 }

--- a/src/main/java/net/teamuni/dailyreward/Dailyreward.java
+++ b/src/main/java/net/teamuni/dailyreward/Dailyreward.java
@@ -3,6 +3,7 @@ package net.teamuni.dailyreward;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
@@ -32,9 +33,8 @@ public final class Dailyreward extends JavaPlugin implements Listener {
     public void onDisable() {
     }
 
-    public YamlConfiguration rewardsYmlLoad() {
-        File file = new File(this.getDataFolder(), "rewards.yml");
-        return YamlConfiguration.loadConfiguration(file);
+    public FileConfiguration rewardsYmlLoad() {
+        return rewardManager.getrewardsFile();
     }
 
 

--- a/src/main/java/net/teamuni/dailyreward/Dailyreward.java
+++ b/src/main/java/net/teamuni/dailyreward/Dailyreward.java
@@ -4,14 +4,12 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.File;
 
 public final class Dailyreward extends JavaPlugin implements Listener {
     private RewardManager rewardManager;
@@ -31,10 +29,6 @@ public final class Dailyreward extends JavaPlugin implements Listener {
 
     @Override
     public void onDisable() {
-    }
-
-    public FileConfiguration rewardsYmlLoad() {
-        return rewardManager.getrewardsFile();
     }
 
 

--- a/src/main/java/net/teamuni/dailyreward/Dailyreward.java
+++ b/src/main/java/net/teamuni/dailyreward/Dailyreward.java
@@ -3,6 +3,7 @@ package net.teamuni.dailyreward;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -17,12 +18,13 @@ public final class Dailyreward extends JavaPlugin implements Listener {
         this.rewardManager = new RewardManager();
         getServer().getPluginManager().registerEvents(new ClickEvent(rewardManager), this);
         rewardManager.createRewardsYml();
-        rewardManager.setGui();
+        rewardManager.setGuiItems();
     }
 
     @Override
     public void onDisable() {
     }
+
 
 
     @Override
@@ -35,7 +37,6 @@ public final class Dailyreward extends JavaPlugin implements Listener {
             if (args.length > 0) {
                 if (args[0].equals("reload")) {
                     rewardManager.reload();
-                    rewardManager.setGui();
                     player.sendMessage(ChatColor.YELLOW + "[알림]" + ChatColor.WHITE + " DailyReward 플러그인이 리로드되었습니다.");
                     return true;
                 }

--- a/src/main/java/net/teamuni/dailyreward/Dailyreward.java
+++ b/src/main/java/net/teamuni/dailyreward/Dailyreward.java
@@ -31,11 +31,11 @@ public final class Dailyreward extends JavaPlugin implements Listener {
     @Override
     public void onDisable() {
     }
-    public YamlConfiguration rewardsYmlLoad(){
+
+    public YamlConfiguration rewardsYmlLoad() {
         File file = new File(this.getDataFolder(), "rewards.yml");
         return YamlConfiguration.loadConfiguration(file);
     }
-
 
 
     @Override

--- a/src/main/java/net/teamuni/dailyreward/Dailyreward.java
+++ b/src/main/java/net/teamuni/dailyreward/Dailyreward.java
@@ -3,11 +3,14 @@ package net.teamuni.dailyreward;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
-import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
 
 public final class Dailyreward extends JavaPlugin implements Listener {
     private RewardManager rewardManager;
@@ -16,13 +19,21 @@ public final class Dailyreward extends JavaPlugin implements Listener {
     @Override
     public void onEnable() {
         this.rewardManager = new RewardManager();
-        getServer().getPluginManager().registerEvents(new ClickEvent(rewardManager), this);
+        getServer().getPluginManager().registerEvents(new ClickEvent(this), this);
         rewardManager.createRewardsYml();
         rewardManager.setGuiItems();
     }
 
+    public Inventory getGui() {
+        return rewardManager.dailyRewardGui;
+    }
+
     @Override
     public void onDisable() {
+    }
+    public YamlConfiguration rewardsYmlLoad(){
+        File file = new File(this.getDataFolder(), "rewards.yml");
+        return YamlConfiguration.loadConfiguration(file);
     }
 
 

--- a/src/main/java/net/teamuni/dailyreward/Dailyreward.java
+++ b/src/main/java/net/teamuni/dailyreward/Dailyreward.java
@@ -18,13 +18,16 @@ public final class Dailyreward extends JavaPlugin implements Listener {
     @Override
     public void onEnable() {
         this.rewardManager = new RewardManager();
-        getServer().getPluginManager().registerEvents(new ClickEvent(this), this);
         rewardManager.createRewardsYml();
         rewardManager.setGuiItems();
+        getServer().getPluginManager().registerEvents(new ClickEvent(this), this);
     }
 
     public Inventory getGui() {
         return rewardManager.dailyRewardGui;
+    }
+    public FileConfiguration getRewardsFileConfiguration(){
+        return rewardManager.getRewardsFile();
     }
 
     @Override

--- a/src/main/java/net/teamuni/dailyreward/RewardManager.java
+++ b/src/main/java/net/teamuni/dailyreward/RewardManager.java
@@ -8,7 +8,6 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.ItemFactory;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -25,7 +24,7 @@ public class RewardManager implements Listener {
     private FileConfiguration rewardsFile = null;
     public final Inventory dailyRewardGui = Bukkit.createInventory(null, 54, ChatColor.GREEN + "출석체크 GUI");
     public final Map<Integer, ItemStack> rewards = new HashMap<>();
-    public final Map<Integer, List<String>> commands = new HashMap<>();
+    public Map<Integer, List<String>> commands = new HashMap<>();
 
     public void createRewardsYml() {
         this.file = new File(main.getDataFolder(), "rewards.yml");
@@ -69,7 +68,6 @@ public class RewardManager implements Listener {
                     rewardLoreList.add(ChatColor.translateAlternateColorCodes('&', lores));
                 }
                 List<String> commandList = new ArrayList<>(sectionSecond.getStringList("commands"));
-                commands.put(slot, commandList);
                 if (rewardsName != null) {
                     meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', rewardsName));
                 } else {
@@ -79,12 +77,18 @@ public class RewardManager implements Listener {
                 meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
                 rewardsItem.setItemMeta(meta);
                 rewards.put(slot, rewardsItem);
+                commands.put(slot, commandList);
             } catch (IllegalArgumentException e) {
                 e.printStackTrace();
             }
         }
         return rewards;
     }
+    public Map<Integer, List<String>> getCommandsMap() {
+        return commands;
+    }
+
+
 
     public void setGui(){
         this.dailyItem.putAll(getRewards("Rewards"));

--- a/src/main/java/net/teamuni/dailyreward/RewardManager.java
+++ b/src/main/java/net/teamuni/dailyreward/RewardManager.java
@@ -49,7 +49,7 @@ public class RewardManager implements Listener {
      */
 
     @NotNull
-    public Map<Integer, ItemStack> getRewards(){
+    public Map<Integer, ItemStack> getRewards() {
         ConfigurationSection section = this.rewardsFile.getConfigurationSection("Rewards");
         Map<Integer, ItemStack> rewards = new HashMap<>();
         Set<String> rewardsKeys = section.getKeys(false);
@@ -64,7 +64,7 @@ public class RewardManager implements Listener {
                 ItemMeta meta = rewardsItem.getItemMeta();
                 String rewardsName = sectionSecond.getString("name");
                 List<String> rewardLoreList = new ArrayList<>();
-                for (String lores : sectionSecond.getStringList("lore")){
+                for (String lores : sectionSecond.getStringList("lore")) {
                     rewardLoreList.add(ChatColor.translateAlternateColorCodes('&', lores));
                 }
                 if (rewardsName != null) {
@@ -83,12 +83,12 @@ public class RewardManager implements Listener {
         return rewards;
     }
 
-    public void setGuiItems(){
+    public void setGuiItems() {
         this.dailyItem.putAll(getRewards());
         for (ItemStack itemStack : this.dailyItem.values()) {
             this.dailyItemMetaSet.add(itemStack.getItemMeta());
         }
-        for (Map.Entry<Integer, ItemStack> dailyitems : this.dailyItem.entrySet()){
+        for (Map.Entry<Integer, ItemStack> dailyitems : this.dailyItem.entrySet()) {
             this.dailyRewardGui.setItem(dailyitems.getKey(), dailyitems.getValue());
         }
     }

--- a/src/main/java/net/teamuni/dailyreward/RewardManager.java
+++ b/src/main/java/net/teamuni/dailyreward/RewardManager.java
@@ -36,6 +36,7 @@ public class RewardManager implements Listener {
 
     public void reload() {
         this.rewardsFile = YamlConfiguration.loadConfiguration(file);
+        setGuiItems();
     }
 
     /*
@@ -49,8 +50,8 @@ public class RewardManager implements Listener {
      */
 
     @NotNull
-    public Map<Integer, ItemStack> getRewards(String path){
-        ConfigurationSection section = this.rewardsFile.getConfigurationSection(path);
+    public Map<Integer, ItemStack> getRewards(){
+        ConfigurationSection section = this.rewardsFile.getConfigurationSection("Rewards");
         Map<Integer, ItemStack> rewards = new HashMap<>();
         Set<String> rewardsKeys = section.getKeys(false);
         if (rewardsKeys.isEmpty()) {
@@ -83,8 +84,8 @@ public class RewardManager implements Listener {
         return rewards;
     }
 
-    public void setGui(){
-        this.dailyItem.putAll(getRewards("Rewards"));
+    public void setGuiItems(){
+        this.dailyItem.putAll(getRewards());
         for (ItemStack itemStack : this.dailyItem.values()) {
             this.dailyItemMetaSet.add(itemStack.getItemMeta());
         }

--- a/src/main/java/net/teamuni/dailyreward/RewardManager.java
+++ b/src/main/java/net/teamuni/dailyreward/RewardManager.java
@@ -3,7 +3,6 @@ package net.teamuni.dailyreward;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
-import org.bukkit.configuration.Configuration;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;

--- a/src/main/java/net/teamuni/dailyreward/RewardManager.java
+++ b/src/main/java/net/teamuni/dailyreward/RewardManager.java
@@ -33,13 +33,13 @@ public class RewardManager implements Listener {
         this.rewardsFile = YamlConfiguration.loadConfiguration(file);
     }
 
+    public FileConfiguration getRewardsFile() {
+        return this.rewardsFile;
+    }
+
     public void reload() {
         this.rewardsFile = YamlConfiguration.loadConfiguration(file);
         setGuiItems();
-    }
-
-    public FileConfiguration getrewardsFile() {
-        return this.rewardsFile;
     }
 
     /*

--- a/src/main/java/net/teamuni/dailyreward/RewardManager.java
+++ b/src/main/java/net/teamuni/dailyreward/RewardManager.java
@@ -8,13 +8,13 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemFactory;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.*;
 
 public class RewardManager implements Listener {
@@ -24,6 +24,8 @@ public class RewardManager implements Listener {
     private File file = null;
     private FileConfiguration rewardsFile = null;
     public final Inventory dailyRewardGui = Bukkit.createInventory(null, 54, ChatColor.GREEN + "출석체크 GUI");
+    public final Map<Integer, ItemStack> rewards = new HashMap<>();
+    public final Map<Integer, List<String>> commands = new HashMap<>();
 
     public void createRewardsYml() {
         this.file = new File(main.getDataFolder(), "rewards.yml");
@@ -50,7 +52,6 @@ public class RewardManager implements Listener {
 
     @NotNull
     public Map<Integer, ItemStack> getRewards(String path){
-        Map<Integer, ItemStack> rewards = new HashMap<>();
         ConfigurationSection section = this.rewardsFile.getConfigurationSection(path);
         Set<String> rewardsKeys = section.getKeys(false);
         if (rewardsKeys.isEmpty()) {
@@ -64,13 +65,11 @@ public class RewardManager implements Listener {
                 ItemMeta meta = rewardsItem.getItemMeta();
                 String rewardsName = sectionSecond.getString("name");
                 List<String> rewardLoreList = new ArrayList<>();
-                List<String> commandList = new ArrayList<>();
                 for (String lores : sectionSecond.getStringList("lore")){
                     rewardLoreList.add(ChatColor.translateAlternateColorCodes('&', lores));
                 }
-                for (String commands : sectionSecond.getStringList("commands")){
-                    commandList.add(commands);
-                }
+                List<String> commandList = new ArrayList<>(sectionSecond.getStringList("commands"));
+                commands.put(slot, commandList);
                 if (rewardsName != null) {
                     meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', rewardsName));
                 } else {

--- a/src/main/java/net/teamuni/dailyreward/RewardManager.java
+++ b/src/main/java/net/teamuni/dailyreward/RewardManager.java
@@ -3,6 +3,7 @@ package net.teamuni.dailyreward;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
+import org.bukkit.configuration.Configuration;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -23,8 +24,6 @@ public class RewardManager implements Listener {
     private File file = null;
     private FileConfiguration rewardsFile = null;
     public final Inventory dailyRewardGui = Bukkit.createInventory(null, 54, ChatColor.GREEN + "출석체크 GUI");
-    public final Map<Integer, ItemStack> rewards = new HashMap<>();
-    public Map<Integer, List<String>> commands = new HashMap<>();
 
     public void createRewardsYml() {
         this.file = new File(main.getDataFolder(), "rewards.yml");
@@ -52,13 +51,14 @@ public class RewardManager implements Listener {
     @NotNull
     public Map<Integer, ItemStack> getRewards(String path){
         ConfigurationSection section = this.rewardsFile.getConfigurationSection(path);
+        Map<Integer, ItemStack> rewards = new HashMap<>();
         Set<String> rewardsKeys = section.getKeys(false);
         if (rewardsKeys.isEmpty()) {
             throw new IllegalArgumentException("rewards.yml 파일의 내용이 비어있습니다. rewards.yml파일을 확인해주세요.");
         }
         for (String key : rewardsKeys) {
             ConfigurationSection sectionSecond = section.getConfigurationSection(key);
-            int slot = section.getInt(key + ".slot");
+            int slot = sectionSecond.getInt("slot");
             try {
                 ItemStack rewardsItem = new ItemStack(Material.valueOf(sectionSecond.getString("item_type")));
                 ItemMeta meta = rewardsItem.getItemMeta();
@@ -67,7 +67,6 @@ public class RewardManager implements Listener {
                 for (String lores : sectionSecond.getStringList("lore")){
                     rewardLoreList.add(ChatColor.translateAlternateColorCodes('&', lores));
                 }
-                List<String> commandList = new ArrayList<>(sectionSecond.getStringList("commands"));
                 if (rewardsName != null) {
                     meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', rewardsName));
                 } else {
@@ -77,18 +76,12 @@ public class RewardManager implements Listener {
                 meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
                 rewardsItem.setItemMeta(meta);
                 rewards.put(slot, rewardsItem);
-                commands.put(slot, commandList);
             } catch (IllegalArgumentException e) {
                 e.printStackTrace();
             }
         }
         return rewards;
     }
-    public Map<Integer, List<String>> getCommandsMap() {
-        return commands;
-    }
-
-
 
     public void setGui(){
         this.dailyItem.putAll(getRewards("Rewards"));

--- a/src/main/java/net/teamuni/dailyreward/RewardManager.java
+++ b/src/main/java/net/teamuni/dailyreward/RewardManager.java
@@ -38,6 +38,10 @@ public class RewardManager implements Listener {
         setGuiItems();
     }
 
+    public FileConfiguration getrewardsFile() {
+        return this.rewardsFile;
+    }
+
     /*
     public void save() {
         try{


### PR DESCRIPTION
테스트 케이스 :
* GUI의 아이템을 클릭했을 때, rewards.yml에서 설정한 명령어가 잘 실행되나 확인하기
* 명령어가 여러줄로 설정을 했을 때, 순차적으로 실행되는지 확인하기
* 플레이어의 권한을 뺐을 때도 GUI의 아이템을 클릭했을 때 권한이 필요한 명령어가 실행이 잘 작동되는지 확인하기.

![image](https://user-images.githubusercontent.com/71818357/194047827-4ce7b5d8-a9ec-4d64-8ef2-1028fd2f5dc8.png)

![image](https://user-images.githubusercontent.com/71818357/194047796-0896cf2f-b678-48da-b9e8-2d41093444a4.png)

![image](https://user-images.githubusercontent.com/71818357/194047948-a5a2e3a0-c643-4835-9bdd-876088d08876.png)

결과 : 
* "day3"에 설정된 commands 의 목록들이 두번째 사진처럼 순차적으로 실행이 잘 되는것을 확인.
* 관리자 권한을 뺐을 때도 GUI의 아이템을 클릭했을 때, 권한이 필요한 명령어라도 실행이 잘 되는것을 확인.