### PR TITLE
보상 GUI 아이템에 플레이어의 보상 수령, 미수령을 확인할 수 있는 로어 추가하기

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,151 @@
 # DailyReward
+## Description
+서버에 출석체크 기능을 추가할 수 있게 해주는 플러그인 입니다.
+### Use Spigot Version:
+1.18.2
+
+### Tested Spigot Version:
+1.18.2
+
+### Required Plugin:
+X
+
+## Install Guide
+1. 릴리즈된 최신 버전의 플러그인 파일을 다운로드 합니다.  
+2. 다운로드한 DailyReward.jar 파일을 플러그인 디렉토리에 저장합니다.
+
+## Feature
+### 출석체크 GUI 커스텀 가능
+플러그인이 첫 활성화 되었을 때 생성되는  
+rewards.yml 파일에서 사용자가 직접 출석체크의 GUI를 커스텀할 수 있습니다.  
+
+rewards.yml의 양식은 다음과 같습니다.
+```Rewards:
+  day1: #day(1~54)
+    slot: 10 #0~53
+    name: "&a1일차 보상" #GUI 아이템의 이름
+    item_type: "EMERALD" #GUI 아이템의 타입
+    lore:
+      - "&e%rewards_receipt_status%" #%rewards_receipt_status% - 플레이어 데이터 파일값에 따라 바뀌는 아이템 수령 여부
+      - "&e보상 목록 :"
+      - "&f철괴 5개"
+      - "&f금괴 5개"
+    commands:
+      - "give @s minecraft:iron_ingot 5" #플레이어가 클릭했을때 실행되는 명령어, /는 빼고 입력.
+      - "give @s minecraft:gold_ingot 5"
+```
+rewards.yml 사용 예제 (해당 예제는 플러그인 첫 실행시에 적용되어있습니다.) :
+```
+Rewards:
+  day1: 
+    slot: 10 
+    name: "&a1일차 보상"
+    item_type: "EMERALD"
+    lore:
+      - "&e%rewards_receipt_status%"
+      - "&e보상 목록 :"
+      - "&f철괴 5개"
+      - "&f금괴 5개"
+    commands:
+      - "give @s minecraft:iron_ingot 5"
+      - "give @s minecraft:gold_ingot 5"
+  day2:
+    slot: 11
+    name: "&a2일차 보상"
+    item_type: "EMERALD"
+    lore:
+      - "&e%rewards_receipt_status%"
+      - "&e보상 목록 :"
+      - "&f철괴 10개"
+      - "&f금괴 10개"
+    commands:
+      - "give @s minecraft:iron_ingot 10"
+      - "give @s minecraft:gold_ingot 10"
+  day3:
+    slot: 12
+    name: "&a3일차 보상"
+    item_type: "EMERALD"
+    lore:
+      - "&e%rewards_receipt_status%"
+      - "&e보상 목록 :"
+      - "&f철괴 20개"
+      - "&f금괴 20개"
+    commands:
+      - "give @s minecraft:iron_ingot 20"
+      - "give @s minecraft:gold_ingot 20"
+  day4:
+    slot: 13
+    name: "&a4일차 보상"
+    item_type: "EMERALD"
+    lore:
+      - "&e%rewards_receipt_status%"
+      - "&e보상 목록 :"
+      - "&f철괴 30개"
+      - "&f금괴 30개"
+    commands:
+      - "give @s minecraft:iron_ingot 30"
+      - "give @s minecraft:gold_ingot 30"
+  day5:
+    slot: 14
+    name: "&a5일차 보상"
+    item_type: "EMERALD"
+    lore:
+      - "&e%rewards_receipt_status%"
+      - "&e보상 목록 :"
+      - "&f철괴 30개"
+      - "&f금괴 30개"
+      - "&f다이아몬드 5개"
+    commands:
+      - "give @s minecraft:iron_ingot 20"
+      - "give @s minecraft:gold_ingot 20"
+      - "give @s minecraft:diamond 5"
+  day6:
+    slot: 15
+    name: "&a6일차 보상"
+    item_type: "EMERALD"
+    lore:
+      - "&e%rewards_receipt_status%"
+      - "&e보상 목록 :"
+      - "&f철괴 30개"
+      - "&f금괴 30개"
+      - "&f다이아몬드 10개"
+    commands:
+      - "give @s minecraft:iron_ingot 20"
+      - "give @s minecraft:gold_ingot 20"
+      - "give @s minecraft:diamond 10"
+  day7:
+    slot: 16
+    name: "&a7일차 보상"
+    item_type: "EMERALD"
+    lore:
+      - "&e%rewards_receipt_status%"
+      - "&e보상 목록 :"
+      - "&f철괴 30개"
+      - "&f금괴 30개"
+      - "&f다이아몬드 15개"
+    commands:
+      - "give @s minecraft:iron_ingot 20"
+      - "give @s minecraft:gold_ingot 20"
+      - "give @s minecraft:diamond 15"
+```
+
+### 플레이어 데이터 파일 관리
+플레이어 데이터 파일은 플레이어가 첫 접속할 시 plugin/Dailyreward/Players 폴더에  
+플레이어의 UUID를 이름으로 하는 YAML 파일이 생성됩니다.  
+
+(플레이어 UUID).yml 파일의 양식
+```
+CumulativeDate: 1
+LastJoinDate: {}
+ReceivedRewards: {}
+```
+CumulativeDate는 플레이어의 누적 접속일이며, 보상의 일차보다 누적 접속일이 적을시에는  
+플레이어는 그 보상의 일차를 획득할 수 없습니다.  
+
+LastJoinDate는 플레이어의 마지막 접속일이며 플레이어가 접속을 했을때 마지막 접속일이
+접속날과 다를시에 CumulativeDate 값이 1씩 늘어납니다.
+
+ReceivedRewards는 플레이어가 획득한 보상들입니다.
+
+만약 모든 플레이어의 데이터를 삭제하고 싶을 때는  
+plugin/Dailyreward/Players 폴더를 통째로 삭제하는식으로 관리할 수 있습니다.

--- a/src/main/java/net/teamuni/dailyreward/Dailyreward.java
+++ b/src/main/java/net/teamuni/dailyreward/Dailyreward.java
@@ -60,8 +60,7 @@ public final class Dailyreward extends JavaPlugin implements Listener {
     public boolean onCommand(@NotNull CommandSender sender, Command cmd, @NotNull String label, String[] args) {
         Player player = (Player) sender;
         if (cmd.getName().equals("출석체크") && player.hasPermission("dailyreward.opengui")) {
-            rewardManager.setGui(player.getUniqueId());
-            player.openInventory(rewardManager.dailyRewardGui);
+            rewardManager.openGui(player);
         }
         if (cmd.getName().equals("dailyreward") && player.hasPermission("dailyreward.reload")) {
             if (args.length > 0) {

--- a/src/main/java/net/teamuni/dailyreward/Dailyreward.java
+++ b/src/main/java/net/teamuni/dailyreward/Dailyreward.java
@@ -32,10 +32,6 @@ public final class Dailyreward extends JavaPlugin implements Listener {
         return plugin;
     }
 
-    public Inventory getGui() {
-        return rewardManager.dailyRewardGui;
-    }
-
     public FileConfiguration getRewardsFileConfiguration() {
         return rewardManager.getRewardsFile();
     }

--- a/src/main/java/net/teamuni/dailyreward/Dailyreward.java
+++ b/src/main/java/net/teamuni/dailyreward/Dailyreward.java
@@ -15,7 +15,6 @@ import java.util.UUID;
 
 public final class Dailyreward extends JavaPlugin implements Listener {
     private RewardManager rewardManager;
-    public UUID playerUuid;
     public Dailyreward plugin;
 
 
@@ -25,7 +24,6 @@ public final class Dailyreward extends JavaPlugin implements Listener {
         this.rewardManager = new RewardManager();
         createFolder();
         rewardManager.createRewardsYml();
-        rewardManager.setGui();
         getServer().getPluginManager().registerEvents(new Event(this), this);
     }
 
@@ -36,9 +34,6 @@ public final class Dailyreward extends JavaPlugin implements Listener {
 
     public Inventory getGui() {
         return rewardManager.dailyRewardGui;
-    }
-    public UUID getPlayerUuid() {
-        return playerUuid;
     }
 
     public FileConfiguration getRewardsFileConfiguration() {
@@ -65,8 +60,7 @@ public final class Dailyreward extends JavaPlugin implements Listener {
     public boolean onCommand(@NotNull CommandSender sender, Command cmd, @NotNull String label, String[] args) {
         Player player = (Player) sender;
         if (cmd.getName().equals("출석체크") && player.hasPermission("dailyreward.opengui")) {
-            playerUuid = player.getUniqueId();
-            rewardManager.setGui();
+            rewardManager.setGui(player.getUniqueId());
             player.openInventory(rewardManager.dailyRewardGui);
         }
         if (cmd.getName().equals("dailyreward") && player.hasPermission("dailyreward.reload")) {

--- a/src/main/java/net/teamuni/dailyreward/Dailyreward.java
+++ b/src/main/java/net/teamuni/dailyreward/Dailyreward.java
@@ -11,9 +11,11 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
+import java.util.UUID;
 
 public final class Dailyreward extends JavaPlugin implements Listener {
     private RewardManager rewardManager;
+    public UUID playerUuid;
     public Dailyreward plugin;
 
 
@@ -34,6 +36,9 @@ public final class Dailyreward extends JavaPlugin implements Listener {
 
     public Inventory getGui() {
         return rewardManager.dailyRewardGui;
+    }
+    public UUID getPlayerUuid() {
+        return playerUuid;
     }
 
     public FileConfiguration getRewardsFileConfiguration() {
@@ -60,6 +65,8 @@ public final class Dailyreward extends JavaPlugin implements Listener {
     public boolean onCommand(@NotNull CommandSender sender, Command cmd, @NotNull String label, String[] args) {
         Player player = (Player) sender;
         if (cmd.getName().equals("출석체크") && player.hasPermission("dailyreward.opengui")) {
+            playerUuid = player.getUniqueId();
+            rewardManager.setGui();
             player.openInventory(rewardManager.dailyRewardGui);
         }
         if (cmd.getName().equals("dailyreward") && player.hasPermission("dailyreward.reload")) {

--- a/src/main/java/net/teamuni/dailyreward/Event.java
+++ b/src/main/java/net/teamuni/dailyreward/Event.java
@@ -27,7 +27,6 @@ public class Event implements Listener {
     public Dailyreward plugin;
 
     public Event(Dailyreward dailyreward) {
-        this.inventory = dailyreward.getGui();
         this.rewardsFile = dailyreward.getRewardsFileConfiguration();
         this.plugin = dailyreward.getPlugin();
     }
@@ -81,7 +80,7 @@ public class Event implements Listener {
 
     @EventHandler
     public void clickEvent(InventoryClickEvent event) {
-        if (!event.getInventory().equals(inventory)) return;
+        if (!event.getView().getTitle().equals(ChatColor.GREEN + "출석체크 GUI")) return;
         event.setCancelled(true);
         if (event.getCurrentItem() == null) return;
         String key = getDayBySlot(event.getSlot());
@@ -129,7 +128,7 @@ public class Event implements Listener {
 
     @EventHandler
     public void dragEvent(InventoryDragEvent e) {
-        if (e.getInventory().equals(inventory)) {
+        if (e.getView().getTitle().equals(ChatColor.GREEN + "출석체크 GUI")) {
             e.setCancelled(true);
         }
     }

--- a/src/main/java/net/teamuni/dailyreward/RewardManager.java
+++ b/src/main/java/net/teamuni/dailyreward/RewardManager.java
@@ -19,10 +19,8 @@ import java.util.*;
 
 public class RewardManager implements Listener {
     private final Dailyreward main = Dailyreward.getPlugin(Dailyreward.class);
-    private final Map<Integer, ItemStack> dailyItem = new HashMap<>();
     private File file = null;
     private FileConfiguration rewardsFile = null;
-    public final Inventory dailyRewardGui = Bukkit.createInventory(null, 54, ChatColor.GREEN + "출석체크 GUI");
 
     public void createRewardsYml() {
         this.file = new File(main.getDataFolder(), "rewards.yml");
@@ -105,15 +103,13 @@ public class RewardManager implements Listener {
         return rewards;
     }
 
-    public void setGui(UUID uuid) {
-        this.dailyItem.putAll(getRewards(uuid));
-        for (Map.Entry<Integer, ItemStack> dailyItems : this.dailyItem.entrySet()) {
-            this.dailyRewardGui.setItem(dailyItems.getKey(), dailyItems.getValue());
-        }
-    }
-
     public void openGui(Player player){
-        setGui(player.getUniqueId());
-        player.openInventory(this.dailyRewardGui);
+        Inventory dailyRewardGui = Bukkit.createInventory(null, 54, ChatColor.GREEN + "출석체크 GUI");
+        Map<Integer, ItemStack> dailyItem = new HashMap<>(getRewards(player.getUniqueId()));
+        for (Map.Entry<Integer, ItemStack> dailyItems : dailyItem.entrySet()) {
+            dailyRewardGui.setItem(dailyItems.getKey(), dailyItems.getValue());
+        }
+        player.openInventory(dailyRewardGui);
     }
 }
+

--- a/src/main/java/net/teamuni/dailyreward/RewardManager.java
+++ b/src/main/java/net/teamuni/dailyreward/RewardManager.java
@@ -38,7 +38,6 @@ public class RewardManager implements Listener {
 
     public void reload() {
         this.rewardsFile = YamlConfiguration.loadConfiguration(file);
-        setGui();
     }
 
     /*
@@ -52,8 +51,7 @@ public class RewardManager implements Listener {
      */
 
     @NotNull
-    public Map<Integer, ItemStack> getRewards() {
-        UUID uuid = main.getPlayerUuid();
+    public Map<Integer, ItemStack> getRewards(UUID uuid) {
         File file = new File("plugins/Dailyreward/Players", uuid + ".yml");
         FileConfiguration playerFile = YamlConfiguration.loadConfiguration(file);
         ConfigurationSection section = this.rewardsFile.getConfigurationSection("Rewards");
@@ -106,8 +104,8 @@ public class RewardManager implements Listener {
         return rewards;
     }
 
-    public void setGui() {
-        this.dailyItem.putAll(getRewards());
+    public void setGui(UUID uuid) {
+        this.dailyItem.putAll(getRewards(uuid));
         for (Map.Entry<Integer, ItemStack> dailyItems : this.dailyItem.entrySet()) {
             this.dailyRewardGui.setItem(dailyItems.getKey(), dailyItems.getValue());
         }

--- a/src/main/java/net/teamuni/dailyreward/RewardManager.java
+++ b/src/main/java/net/teamuni/dailyreward/RewardManager.java
@@ -74,7 +74,7 @@ public class RewardManager implements Listener {
                 for (String lores : sectionSecond.getStringList("lore")) {
                     if(lores.contains("%rewards_receipt_status%")) {
                         if (keyDay > playerFile.getInt("CumulativeDate")) {
-                            String placeholderLore = lores.replace("%rewards_receipt_status%", String.valueOf(playerFile.getInt("CumulativeDate")));
+                            String placeholderLore = lores.replace("%rewards_receipt_status%", "아직 해당 일차보상을 획득할 수 없습니다.");
                             rewardLoreList.add(ChatColor.translateAlternateColorCodes('&', placeholderLore));
                         } else {
                             List<String> rewardList = playerFile.getStringList("ReceivedRewards");

--- a/src/main/java/net/teamuni/dailyreward/RewardManager.java
+++ b/src/main/java/net/teamuni/dailyreward/RewardManager.java
@@ -6,6 +6,7 @@ import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemFlag;
@@ -109,5 +110,10 @@ public class RewardManager implements Listener {
         for (Map.Entry<Integer, ItemStack> dailyItems : this.dailyItem.entrySet()) {
             this.dailyRewardGui.setItem(dailyItems.getKey(), dailyItems.getValue());
         }
+    }
+
+    public void openGui(Player player){
+        setGui(player.getUniqueId());
+        player.openInventory(this.dailyRewardGui);
     }
 }

--- a/src/main/resources/rewards.yml
+++ b/src/main/resources/rewards.yml
@@ -1,9 +1,91 @@
 Rewards:
-  day1:
-    slot: 0
-    name: "&a1일차 보상"
+  day1: #day(1~54)
+    slot: 10 #0~53
+    name: "&a1일차 보상" #GUI 아이템의 이름
+    item_type: "EMERALD" #GUI 아이템의 타입
+    lore:
+      - "&e%rewards_receipt_status%" #%rewards_receipt_status% - 플레이어 데이터 파일값에 따라 바뀌는 아이템 수령 여부
+      - "&e보상 목록 :"
+      - "&f철괴 5개"
+      - "&f금괴 5개"
+    commands:
+      - "give @s minecraft:iron_ingot 5" #플레이어가 클릭했을때 실행되는 명령어, /는 빼고 입력.
+      - "give @s minecraft:gold_ingot 5"
+  day2:
+    slot: 11
+    name: "&a2일차 보상"
     item_type: "EMERALD"
     lore:
-      - ""
+      - "&e%rewards_receipt_status%"
+      - "&e보상 목록 :"
+      - "&f철괴 10개"
+      - "&f금괴 10개"
     commands:
-      - ""
+      - "give @s minecraft:iron_ingot 10"
+      - "give @s minecraft:gold_ingot 10"
+  day3:
+    slot: 12
+    name: "&a3일차 보상"
+    item_type: "EMERALD"
+    lore:
+      - "&e%rewards_receipt_status%"
+      - "&e보상 목록 :"
+      - "&f철괴 20개"
+      - "&f금괴 20개"
+    commands:
+      - "give @s minecraft:iron_ingot 20"
+      - "give @s minecraft:gold_ingot 20"
+  day4:
+    slot: 13
+    name: "&a4일차 보상"
+    item_type: "EMERALD"
+    lore:
+      - "&e%rewards_receipt_status%"
+      - "&e보상 목록 :"
+      - "&f철괴 30개"
+      - "&f금괴 30개"
+    commands:
+      - "give @s minecraft:iron_ingot 30"
+      - "give @s minecraft:gold_ingot 30"
+  day5:
+    slot: 14
+    name: "&a5일차 보상"
+    item_type: "EMERALD"
+    lore:
+      - "&e%rewards_receipt_status%"
+      - "&e보상 목록 :"
+      - "&f철괴 30개"
+      - "&f금괴 30개"
+      - "&f다이아몬드 5개"
+    commands:
+      - "give @s minecraft:iron_ingot 20"
+      - "give @s minecraft:gold_ingot 20"
+      - "give @s minecraft:diamond 5"
+  day6:
+    slot: 15
+    name: "&a6일차 보상"
+    item_type: "EMERALD"
+    lore:
+      - "&e%rewards_receipt_status%"
+      - "&e보상 목록 :"
+      - "&f철괴 30개"
+      - "&f금괴 30개"
+      - "&f다이아몬드 10개"
+    commands:
+      - "give @s minecraft:iron_ingot 20"
+      - "give @s minecraft:gold_ingot 20"
+      - "give @s minecraft:diamond 10"
+  day7:
+    slot: 16
+    name: "&a7일차 보상"
+    item_type: "EMERALD"
+    lore:
+      - "&e%rewards_receipt_status%"
+      - "&e보상 목록 :"
+      - "&f철괴 30개"
+      - "&f금괴 30개"
+      - "&f다이아몬드 15개"
+    commands:
+      - "give @s minecraft:iron_ingot 20"
+      - "give @s minecraft:gold_ingot 20"
+      - "give @s minecraft:diamond 15"


### PR DESCRIPTION
**테스트 케이스의 테스트 환경 :**
> 1. 테스트 서버 버킷 : purpur-1.18.2-1632.jar
> 2. 테스트한 마인크래프트 버전 : 1.18.2

**테스트 케이스**

확인 해야 하는것:
> 플레이어가 "/출석체크" 명령어를 사용하여 인벤토리를 열었을 때,
> GUI 아이템 로어의 %rewards_receipt_status% 플레이스 홀더가 플레이어의 데이터 파일의 값에 따라
> 변경이 되는지 안되는지를 확인하기.

실행한 단계:
> 1. 플러그인 폴더 내의 rewards.yml 파일 안에 1일차 보상외의 여러보상들을 추가하여 테스트 서버 오픈.
> 2. 테스트 서버에 첫 접속 (CumulativeDate 섹션의 값 : 1)
> 3. "/출석체크" 명령어로 GUI를 열어 아이템들의 플레이스 홀더가 적용된 로어들을 확인
> 4. 1일차 보상을 획득한 후 다시 "/출석체크" 명령어로 GUI를 열어 아이템들의 플레이스 홀더가 적용된 로어들을 확인
> 5. 다음날 다시 재접속 (CumulativeDate 섹션의 값 : 2)
> 6. "/출석체크" 명령어로 GUI를 열어 아이템들의 플레이스 홀더가 적용된 로어들을 확인

예상한 결과:
> 1. 실행한 단계의 3번에서 1일차 보상 로어에는 "해당 일차보상을 수령할 수 있습니다." 라고 로어가 변경되고, 
> 그 이외 보상들의 로어는 "아직 해당 일차의 보상을 획득할 수 없다" 라고 로어가 변경되어야함. 
>
> 2. 실행한 단계의 4번에서 1일차 보상 로어에는 "이미 해당 일차보상을 수령했습니다." 라고 로어가 변경되고, 
> 그 이외 보상들의 로어는 "아직 해당 일차의 보상을 획득할 수 없다" 라고 로어가 변경되어야함. 
>
> 3. 실행한 단계의 6번에서 1일차 보상 로어에는 "이미 해당 일차보상을 수령했습니다." 라고 로어가 변경되고, 
> 2일차 보상 로어에는 "해당 일차보상을 수령할 수 있습니다." 라고 로어가 변경되고, 
> 그 이외 보상들의 로어는 "아직 해당 일차의 보상을 획득할 수 없다" 라고 로어가 변경되어야함.

실제 결과 :
> 예상한 결과랑 같은 결과가 나온것을 확인 [통과]

첨부 사진 : 
> ![image](https://user-images.githubusercontent.com/71818357/197517764-48c1cbb7-7479-44b9-b26a-be5ebdd70470.png)
> ↑ 실행한 단계 3번에서 1일차 보상 로어의 모습
> ![image](https://user-images.githubusercontent.com/71818357/197517839-e0363c01-148f-460c-9e06-5d8334679ce4.png)
> ↑ 실행한 단계 4번에서 1일차 보상 로어의 모습
> ![image](https://user-images.githubusercontent.com/71818357/197518164-4605529d-102e-4f6d-97fa-3841ee29361f.png)
> ↑ 실행한 단계 6번에서 2일차 보상 로어의 모습
> ![image](https://user-images.githubusercontent.com/71818357/197517902-31cdd253-e3c9-47da-aa06-4b2912396fce.png)
> ↑ 실행한 단계 3,4,6번에서 그 이외 보상들의 로어의 모습


