### PR TITLE
GUI를 열거나, GUI의 아이템을 클릭했을때 소리나게끔 하기.

### DIFF
--- a/src/main/java/net/teamuni/dailyreward/Dailyreward.java
+++ b/src/main/java/net/teamuni/dailyreward/Dailyreward.java
@@ -1,6 +1,7 @@
 package net.teamuni.dailyreward;
 
 import org.bukkit.ChatColor;
+import org.bukkit.Sound;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -57,6 +58,7 @@ public final class Dailyreward extends JavaPlugin implements Listener {
         Player player = (Player) sender;
         if (cmd.getName().equals("출석체크") && player.hasPermission("dailyreward.opengui")) {
             rewardManager.openGui(player);
+            player.playSound(player, Sound.BLOCK_CHEST_OPEN, 1,1);
         }
         if (cmd.getName().equals("dailyreward") && player.hasPermission("dailyreward.reload")) {
             if (args.length > 0) {

--- a/src/main/java/net/teamuni/dailyreward/Dailyreward.java
+++ b/src/main/java/net/teamuni/dailyreward/Dailyreward.java
@@ -5,12 +5,14 @@ import org.bukkit.Sound;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
+import java.io.IOException;
 
 public final class Dailyreward extends JavaPlugin implements Listener {
     private RewardManager rewardManager;
@@ -22,6 +24,7 @@ public final class Dailyreward extends JavaPlugin implements Listener {
     public void onEnable() {
         this.rewardManager = new RewardManager();
         createFolder();
+        createConfigFile();
         rewardManager.createRewardsYml();
         getServer().getPluginManager().registerEvents(new Event(this), this);
     }
@@ -39,6 +42,13 @@ public final class Dailyreward extends JavaPlugin implements Listener {
     public void onDisable() {
     }
 
+    public void createConfigFile() {
+        File configFile = new File(getDataFolder(), "config.yml");
+        if (!configFile.exists()) {
+            this.saveResource("config.yml", false);
+        }
+    }
+
     public void createFolder() {
         File folder = new File(getDataFolder(), "Players");
         if (!folder.exists()) {
@@ -54,9 +64,20 @@ public final class Dailyreward extends JavaPlugin implements Listener {
     @Override
     public boolean onCommand(@NotNull CommandSender sender, Command cmd, @NotNull String label, String[] args) {
         Player player = (Player) sender;
+        String openGuiSound = getConfig().getString("Open_Gui_Sound");
+        String[] splitOpenGuiSound;
+        if (openGuiSound != null && !openGuiSound.equals("")) {
+            splitOpenGuiSound = openGuiSound.split("-");
+        } else {
+            player.sendMessage(ChatColor.YELLOW + "[알림]" + ChatColor.WHITE + " config.yml 에 Open_Gui_Sound가 비어있습니다. 관리자에게 연락해주세요.");
+            return true;
+        }
+        Sound splitSound = Sound.valueOf(splitOpenGuiSound[0]);
+        float splitVolume = Float.parseFloat(splitOpenGuiSound[1]);
+        float splitPitch = Float.parseFloat(splitOpenGuiSound[2]);
         if (cmd.getName().equals("출석체크") && player.hasPermission("dailyreward.opengui")) {
             rewardManager.openGui(player);
-            player.playSound(player, Sound.BLOCK_CHEST_OPEN, 1,1);
+            player.playSound(player, splitSound, splitVolume, splitPitch);
         }
         if (cmd.getName().equals("dailyreward") && player.hasPermission("dailyreward.reload")) {
             if (args.length > 0) {

--- a/src/main/java/net/teamuni/dailyreward/Dailyreward.java
+++ b/src/main/java/net/teamuni/dailyreward/Dailyreward.java
@@ -7,12 +7,10 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
-import org.bukkit.inventory.Inventory;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
-import java.util.UUID;
 
 public final class Dailyreward extends JavaPlugin implements Listener {
     private RewardManager rewardManager;

--- a/src/main/java/net/teamuni/dailyreward/Event.java
+++ b/src/main/java/net/teamuni/dailyreward/Event.java
@@ -24,10 +24,18 @@ import java.util.UUID;
 public class Event implements Listener {
     public FileConfiguration rewardsFile;
     public Dailyreward plugin;
+    public String receivedRewardSound;
+    public String notEnoughDaySound;
+    public String alreadyReceivedRewardSound;
+    public String notExistPlayerFileSound;
 
     public Event(Dailyreward dailyreward) {
         this.rewardsFile = dailyreward.getRewardsFileConfiguration();
         this.plugin = dailyreward.getPlugin();
+        this.receivedRewardSound = dailyreward.getConfig().getString("Receive_Reward_Sound");
+        this.notEnoughDaySound = dailyreward.getConfig().getString("Not_Enough_Day_Sound");
+        this.alreadyReceivedRewardSound = dailyreward.getConfig().getString("Already_Received_Reward_Sound");
+        this.notExistPlayerFileSound = dailyreward.getConfig().getString("Not_Exist_Player_File_Sound");
     }
 
     public ConfigurationSection loadConfigurationSection() {
@@ -87,16 +95,24 @@ public class Event implements Listener {
         Player player = (Player) event.getWhoClicked();
         File file = new File("plugins/Dailyreward/Players", player.getUniqueId() + ".yml");
         if (!file.exists()) {
+            String[] splitNotExistPlayerFileSound = notExistPlayerFileSound.split("-");
+            Sound splitSound = Sound.valueOf(splitNotExistPlayerFileSound[0]);
+            float splitVolume = Float.parseFloat(splitNotExistPlayerFileSound[1]);
+            float splitPitch = Float.parseFloat(splitNotExistPlayerFileSound[2]);
             player.sendMessage(ChatColor.YELLOW + "[알림] " + ChatColor.WHITE + "플레이어의 데이터파일이 존재하지 않습니다! 서버에 나갔다가 다시 접속해주세요!");
-            player.playSound(player, Sound.ENTITY_VILLAGER_HURT, 1,1);
+            player.playSound(player, splitSound, splitVolume,splitPitch);
             player.closeInventory();
             return;
         }
         FileConfiguration playerFile = YamlConfiguration.loadConfiguration(file);
         int keyDay = Integer.parseInt(key.replaceAll("\\D", ""));
         if (keyDay > playerFile.getInt("CumulativeDate")) {
+            String[] splitNotEnoughDaySound = notEnoughDaySound.split("-");
+            Sound splitSound = Sound.valueOf(splitNotEnoughDaySound[0]);
+            float splitVolume = Float.parseFloat(splitNotEnoughDaySound[1]);
+            float splitPitch = Float.parseFloat(splitNotEnoughDaySound[2]);
             player.sendMessage(ChatColor.YELLOW + "[알림] " + ChatColor.WHITE + "아직 해당 일차의 보상을 수령할 수 없습니다!");
-            player.playSound(player, Sound.ENTITY_VILLAGER_NO, 1,(float) 1.5);
+            player.playSound(player, splitSound, splitVolume, splitPitch);
             player.closeInventory();
             return;
         }
@@ -106,8 +122,12 @@ public class Event implements Listener {
         String rewardName = section.getString("name");
         List<String> commandList = section.getStringList("commands");
         if (rewardList.contains(key)) {
+            String[] splitAlreadyReceivedRewardSound = alreadyReceivedRewardSound.split("-");
+            Sound splitSound = Sound.valueOf(splitAlreadyReceivedRewardSound[0]);
+            float splitVolume = Float.parseFloat(splitAlreadyReceivedRewardSound[1]);
+            float splitPitch = Float.parseFloat(splitAlreadyReceivedRewardSound[2]);
             player.sendMessage(ChatColor.YELLOW + "[알림] " + ChatColor.translateAlternateColorCodes('&', rewardName) + ChatColor.WHITE + " 을(를) 이미 수령하셨습니다!");
-            player.playSound(player, Sound.ENTITY_VILLAGER_NO, 1,(float) 1.5);
+            player.playSound(player, splitSound, splitVolume, splitPitch);
             player.closeInventory();
             return;
         }
@@ -119,7 +139,11 @@ public class Event implements Listener {
         } finally {
             player.setOp(false);
             player.sendMessage(ChatColor.YELLOW + "[알림] " + ChatColor.translateAlternateColorCodes('&', rewardName) + ChatColor.WHITE + " 을(를) 수령했습니다!");
-            player.playSound(player, Sound.ENTITY_PLAYER_LEVELUP, 1,(float) 1.3);
+            String[] splitReceivedRewardSound = receivedRewardSound.split("-");
+            Sound splitSound = Sound.valueOf(splitReceivedRewardSound[0]);
+            float splitVolume = Float.parseFloat(splitReceivedRewardSound[1]);
+            float splitPitch = Float.parseFloat(splitReceivedRewardSound[2]);
+            player.playSound(player, splitSound, splitVolume, splitPitch);
             try {
                 rewardList.add(key);
                 playerFile.set("ReceivedRewards", rewardList);

--- a/src/main/java/net/teamuni/dailyreward/Event.java
+++ b/src/main/java/net/teamuni/dailyreward/Event.java
@@ -12,7 +12,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.inventory.Inventory;
 
 import java.io.File;
 import java.io.IOException;
@@ -23,7 +22,6 @@ import java.util.Objects;
 import java.util.UUID;
 
 public class Event implements Listener {
-    public Inventory inventory;
     public FileConfiguration rewardsFile;
     public Dailyreward plugin;
 

--- a/src/main/java/net/teamuni/dailyreward/Event.java
+++ b/src/main/java/net/teamuni/dailyreward/Event.java
@@ -2,6 +2,7 @@ package net.teamuni.dailyreward;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.Sound;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -88,13 +89,17 @@ public class Event implements Listener {
         Player player = (Player) event.getWhoClicked();
         File file = new File("plugins/Dailyreward/Players", player.getUniqueId() + ".yml");
         if (!file.exists()) {
-            player.sendMessage(ChatColor.YELLOW + "[알림] " + ChatColor.WHITE + " 플레이어의 데이터파일이 존재하지 않습니다! 서버에 나갔다가 다시 접속해주세요!");
+            player.sendMessage(ChatColor.YELLOW + "[알림] " + ChatColor.WHITE + "플레이어의 데이터파일이 존재하지 않습니다! 서버에 나갔다가 다시 접속해주세요!");
+            player.playSound(player, Sound.ENTITY_VILLAGER_HURT, 1,1);
+            player.closeInventory();
             return;
         }
         FileConfiguration playerFile = YamlConfiguration.loadConfiguration(file);
         int keyDay = Integer.parseInt(key.replaceAll("\\D", ""));
         if (keyDay > playerFile.getInt("CumulativeDate")) {
-            player.sendMessage(ChatColor.YELLOW + "[알림] " + ChatColor.WHITE + " 아직 해당 일차의 보상을 수령할 수 없습니다!");
+            player.sendMessage(ChatColor.YELLOW + "[알림] " + ChatColor.WHITE + "아직 해당 일차의 보상을 수령할 수 없습니다!");
+            player.playSound(player, Sound.ENTITY_VILLAGER_NO, 1,(float) 1.5);
+            player.closeInventory();
             return;
         }
         List<String> rewardList = playerFile.getStringList("ReceivedRewards");
@@ -104,6 +109,7 @@ public class Event implements Listener {
         List<String> commandList = section.getStringList("commands");
         if (rewardList.contains(key)) {
             player.sendMessage(ChatColor.YELLOW + "[알림] " + ChatColor.translateAlternateColorCodes('&', rewardName) + ChatColor.WHITE + " 을(를) 이미 수령하셨습니다!");
+            player.playSound(player, Sound.ENTITY_VILLAGER_NO, 1,(float) 1.5);
             player.closeInventory();
             return;
         }
@@ -115,6 +121,7 @@ public class Event implements Listener {
         } finally {
             player.setOp(false);
             player.sendMessage(ChatColor.YELLOW + "[알림] " + ChatColor.translateAlternateColorCodes('&', rewardName) + ChatColor.WHITE + " 을(를) 수령했습니다!");
+            player.playSound(player, Sound.ENTITY_PLAYER_LEVELUP, 1,(float) 1.3);
             try {
                 rewardList.add(key);
                 playerFile.set("ReceivedRewards", rewardList);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,5 @@
+Open_Gui_Sound: "BLOCK_CHEST_OPEN-1-1" #Sound-volume-pitch 형식으로 작성해주세요!
+Receive_Reward_Sound: "ENTITY_PLAYER_LEVELUP-1-1.3"
+Not_Enough_Day_Sound: "ENTITY_VILLAGER_NO-1-1.5"
+Already_Received_Reward_Sound: "ENTITY_VILLAGER_NO-1-1.5"
+Not_Exist_Player_File_Sound: "ENTITY_VILLAGER_HURT-1-1"


### PR DESCRIPTION
**테스트 케이스의 테스트 환경** :
> 1. 테스트 서버 버킷 : purpur-1.19.2-1825.jar
> 2. 테스트한 마인크래프트 버전 : 1.19.2

**테스트 케이스**

확인해야 하는것 : 
> 플레이어가 /출석체크 명령어를 통해 GUI를 열었을 때, 소리가 나는지 확인.
> 플레이어가 출석체크 아이템을 눌렀을 때 플레이어의 상태에 따라 소리가 나는지 확인.

실행한 단계 :
> 1. 테스트 서버에 접속
> 2. /출석체크 를 통해서 출석체크 GUI를 오픈
> 3. 출석체크 GUI의 보상 아이템을 클릭

예상 결과 :
> 실행한 단계 2번에서 정상적으로 상자가 여는 소리가 나고
> 실행한 단계 3번에서 플레이어의 상태에 맞게 (보상을 받을수 없거나, 보상을 받았을 때) 소리가 남.

실제 결과 :
> 예상 결과랑 같음.
