### PR TITLE
보상을 수령한 후에 다시 GUI를 열면 보상의 GUI 아이템이 바뀌게끔 해보기

### DIFF
--- a/src/main/java/net/teamuni/dailyreward/Dailyreward.java
+++ b/src/main/java/net/teamuni/dailyreward/Dailyreward.java
@@ -6,12 +6,10 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
-import org.bukkit.inventory.Inventory;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
-import java.util.UUID;
 
 public final class Dailyreward extends JavaPlugin implements Listener {
     private RewardManager rewardManager;

--- a/src/main/java/net/teamuni/dailyreward/Event.java
+++ b/src/main/java/net/teamuni/dailyreward/Event.java
@@ -11,7 +11,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.inventory.Inventory;
 
 import java.io.File;
 import java.io.IOException;
@@ -22,7 +21,6 @@ import java.util.Objects;
 import java.util.UUID;
 
 public class Event implements Listener {
-    public Inventory inventory;
     public FileConfiguration rewardsFile;
     public Dailyreward plugin;
 

--- a/src/main/java/net/teamuni/dailyreward/RewardManager.java
+++ b/src/main/java/net/teamuni/dailyreward/RewardManager.java
@@ -56,6 +56,7 @@ public class RewardManager implements Listener {
         ConfigurationSection section = this.rewardsFile.getConfigurationSection("Rewards");
         Map<Integer, ItemStack> rewards = new HashMap<>();
         Set<String> rewardsKeys = section.getKeys(false);
+        List<String> rewardList = playerFile.getStringList("ReceivedRewards");
         if (rewardsKeys.isEmpty()) {
             throw new IllegalArgumentException("rewards.yml 파일의 내용이 비어있습니다. rewards.yml파일을 확인해주세요.");
         }
@@ -64,7 +65,12 @@ public class RewardManager implements Listener {
             int keyDay = Integer.parseInt(key.replaceAll("\\D", ""));
             int slot = sectionSecond.getInt("slot");
             try {
-                ItemStack rewardsItem = new ItemStack(Material.valueOf(sectionSecond.getString("item_type")));
+                ItemStack rewardsItem;
+                if (rewardList.contains(key)) {
+                    rewardsItem = new ItemStack(Material.valueOf(sectionSecond.getString("received_item_type")));
+                } else {
+                    rewardsItem = new ItemStack(Material.valueOf(sectionSecond.getString("item_type")));
+                }
                 ItemMeta meta = rewardsItem.getItemMeta();
                 String rewardsName = sectionSecond.getString("name");
                 List<String> rewardLoreList = new ArrayList<>();
@@ -74,14 +80,13 @@ public class RewardManager implements Listener {
                             String placeholderLore = lores.replace("%rewards_receipt_status%", "아직 해당 일차보상을 획득할 수 없습니다.");
                             rewardLoreList.add(ChatColor.translateAlternateColorCodes('&', placeholderLore));
                         } else {
-                            List<String> rewardList = playerFile.getStringList("ReceivedRewards");
+                            String placeholderLore;
                             if (rewardList.contains(key)) {
-                                String placeholderLore = lores.replace("%rewards_receipt_status%", "이미 해당 일차보상을 수령했습니다.");
-                                rewardLoreList.add(ChatColor.translateAlternateColorCodes('&', placeholderLore));
+                                placeholderLore = lores.replace("%rewards_receipt_status%", "이미 해당 일차보상을 수령했습니다.");
                             } else {
-                                String placeholderLore = lores.replace("%rewards_receipt_status%", "해당 일차보상을 수령할 수 있습니다.");
-                                rewardLoreList.add(ChatColor.translateAlternateColorCodes('&', placeholderLore));
+                                placeholderLore = lores.replace("%rewards_receipt_status%", "해당 일차보상을 수령할 수 있습니다.");
                             }
+                            rewardLoreList.add(ChatColor.translateAlternateColorCodes('&', placeholderLore));
                         }
                     } else {
                         rewardLoreList.add(ChatColor.translateAlternateColorCodes('&', lores));

--- a/src/main/resources/rewards.yml
+++ b/src/main/resources/rewards.yml
@@ -3,6 +3,7 @@ Rewards:
     slot: 10 #0~53
     name: "&a1일차 보상" #GUI 아이템의 이름
     item_type: "EMERALD" #GUI 아이템의 타입
+    received_item_type: "BARRIER" #보상을 받으면 변경되는 GUI 아이템의 타입
     lore:
       - "&e%rewards_receipt_status%" #%rewards_receipt_status% - 플레이어 데이터 파일값에 따라 바뀌는 아이템 수령 여부
       - "&e보상 목록 :"
@@ -15,6 +16,7 @@ Rewards:
     slot: 11
     name: "&a2일차 보상"
     item_type: "EMERALD"
+    received_item_type: "BARRIER"
     lore:
       - "&e%rewards_receipt_status%"
       - "&e보상 목록 :"
@@ -27,6 +29,7 @@ Rewards:
     slot: 12
     name: "&a3일차 보상"
     item_type: "EMERALD"
+    received_item_type: "BARRIER"
     lore:
       - "&e%rewards_receipt_status%"
       - "&e보상 목록 :"
@@ -39,6 +42,7 @@ Rewards:
     slot: 13
     name: "&a4일차 보상"
     item_type: "EMERALD"
+    received_item_type: "BARRIER"
     lore:
       - "&e%rewards_receipt_status%"
       - "&e보상 목록 :"
@@ -51,6 +55,7 @@ Rewards:
     slot: 14
     name: "&a5일차 보상"
     item_type: "EMERALD"
+    received_item_type: "BARRIER"
     lore:
       - "&e%rewards_receipt_status%"
       - "&e보상 목록 :"
@@ -65,6 +70,7 @@ Rewards:
     slot: 15
     name: "&a6일차 보상"
     item_type: "EMERALD"
+    received_item_type: "BARRIER"
     lore:
       - "&e%rewards_receipt_status%"
       - "&e보상 목록 :"
@@ -79,6 +85,7 @@ Rewards:
     slot: 16
     name: "&a7일차 보상"
     item_type: "EMERALD"
+    received_item_type: "BARRIER"
     lore:
       - "&e%rewards_receipt_status%"
       - "&e보상 목록 :"


### PR DESCRIPTION
**테스트 케이스의 테스트 환경** :
> 1. 테스트 서버 버킷 : purpur-1.19.2-1825.jar
> 2. 테스트한 마인크래프트 버전 : 1.19.2

**테스트 케이스**

확인해야 하는것 :
> 플레이어가 보상을 수령하고 다시 GUI를 열면 아이템이 정상적으로 바뀌는지 확인하기

실행한 단계 :
>1. /출석체크 를 통해 출석체크의 GUI를 오픈
>2. 1일차 보상을 획득
>3. 다시 /출석체크 를 통해 출석체크의 GUI를 오픈

예상한 결과 :
> 3번의 출석체크 GUI 에서 1일차 보상 아이템이 rewards.yml에서 received_item_type 에 설정된 아이템인 
> BARRIER로 변경되어야함.

실제 결과 :
> 1일차 보상 아이템이 보상 획득 전의 아이템(EMERALD) 에서 보상 획득 후의 아이템(BARRIER)로 변경됨. (통과)

> 첨부 사진 : 
> ![image](https://user-images.githubusercontent.com/71818357/198579834-979c8016-0acd-4535-a5c7-a76e7397d363.png)


